### PR TITLE
Create global plot list dialog

### DIFF
--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -14,6 +14,7 @@ import { store } from '@/lib/store';
 import { useSelector } from '@xstate/store/react';
 
 import { Link } from './link';
+import { PlotsListDialog } from './plots-list-dialog';
 
 export function Footer() {
     const searchParams = useSearchParams();
@@ -85,6 +86,8 @@ export function Footer() {
                         />
                     </DropdownMenuContent>
                 </DropdownMenu>
+                <div>/ </div>
+                <PlotsListDialog />
                 <div>/ </div>
                 {user != null ? (
                     <>

--- a/web/components/plots-list-dialog.tsx
+++ b/web/components/plots-list-dialog.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+	DialogTrigger,
+	DialogClose,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useQuery } from '@tanstack/react-query';
+
+import { store } from '@/lib/store';
+import { Plot, getUserPlots } from '@/lib/tools/claimer/claimer.rest';
+
+export function PlotsListDialog() {
+	const { data: plots } = useQuery({
+		queryKey: ['user', 'plots'],
+		queryFn: getUserPlots,
+	});
+
+	const sortedPlots: Plot[] | undefined = useMemo(() => {
+		if (!plots) return plots;
+		return [...plots].sort((a, b) => a.name.localeCompare(b.name));
+	}, [plots]);
+
+	return (
+		<Dialog>
+			<DialogTrigger render={(props) => (
+				<Button variant="link" className="px-0" {...props}>
+					plots
+				</Button>
+			)} />
+			<DialogContent className="max-w-xl">
+				<DialogTitle>All plots</DialogTitle>
+				<DialogDescription>
+					Select a plot to navigate to its location.
+				</DialogDescription>
+				<div className="mt-3 divide-y divide-primary/20">
+					{sortedPlots?.map((plot) => (
+						<DialogClose
+							key={plot.id}
+							render={(props) => (
+								<button
+									{...props}
+									onClick={() => {
+										store.trigger.selectPlot({ plotId: plot.id });
+									}}
+									className="block w-full px-2 py-2 text-left hover:bg-primary/5 focus:bg-primary/5 focus:outline-none"
+								>
+									<div className="text-base font-medium leading-tight">{plot.name}</div>
+									{plot.description ? (
+										<div className="text-sm text-muted-foreground line-clamp-2">
+											{plot.description}
+										</div>
+									) : null}
+								</button>
+							)}
+						/>
+					))}
+					{sortedPlots?.length === 0 ? (
+						<div className="px-2 py-2 text-sm text-muted-foreground">No plots yet.</div>
+					) : null}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
Add a global, alphabetically sorted plots list dialog to the footer, allowing users to navigate to and select plots by clicking their title and description.

---
<a href="https://cursor.com/background-agent?bcId=bc-a08bd97f-b837-4ff0-a6b8-ed941ed68f6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a08bd97f-b837-4ff0-a6b8-ed941ed68f6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

