### PR TITLE
Highlight intersecting plots as client errors

### DIFF
--- a/web/lib/geometry/polygon.ts
+++ b/web/lib/geometry/polygon.ts
@@ -216,6 +216,35 @@ export function isIneligiblePolygon(p: Polygon): boolean {
     );
 }
 
+/**
+ * Returns all intersection polygons between two polygons.
+ */
+export function getIntersectionPolygons(
+    polygon1: Polygon,
+    polygon2: Polygon,
+): Polygon[] {
+    if (isIneligiblePolygon(polygon1) || isIneligiblePolygon(polygon2))
+        return [];
+
+    try {
+        // In this codebase, clipArray(..., true) is used for union.
+        // Using false here computes the clipped intersection regions.
+        const result = clipArray([polygon1.vertices], [polygon2.vertices], false);
+        if (!result || result.length === 0) return [];
+
+        return result.map((poly) =>
+            sortPolygonVerticesIntoClockwiseOrder(
+                polygonSchema.parse({ vertices: poly }),
+            ),
+        );
+    } catch (e) {
+        console.log(`Failed to compute polygon intersection of:\n\n${JSON.stringify(
+            polygon1,
+        )}\n\n${JSON.stringify(polygon2)}\n\n`);
+        return [];
+    }
+}
+
 export function getCanvasPolygon(
     centerX: number,
     centerY: number,

--- a/web/lib/webgpu/colors.ts
+++ b/web/lib/webgpu/colors.ts
@@ -3,6 +3,7 @@ export type Color = [number, number, number, number];
 export const BLUE: Color = [0, 0, 1, 1];
 export const BLACK: Color = [0, 0, 0, 1];
 export const CLAIMER_YELLOW: Color = [246 / 255, 240 / 255, 74 / 255, 1];
+export const ERROR_RED: Color = [1, 0, 0, 0.6];
 
 export function hexToRgbaColor(hex: string): Color {
     // Remove # if present

--- a/web/lib/webgpu/web-gpu-manager.ts
+++ b/web/lib/webgpu/web-gpu-manager.ts
@@ -58,6 +58,7 @@ export class WebGPUManager {
                 containsMatchingEndpoints?: boolean;
                 color?: [number, number, number, number];
                 lineWidth?: number;
+                filled?: boolean;
             };
         }>,
     ): void {


### PR DESCRIPTION
Add client-side validation and visual highlighting for plot intersections to prevent overlapping plots.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac460408-6786-494b-9e19-7c1c3dfcea79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac460408-6786-494b-9e19-7c1c3dfcea79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

